### PR TITLE
install scikit-learn instead of sklearn fix #5

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install opencv-python
-	  pip install sklearn
       - name: Test with pytest
         run: |
           pip install pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ d3graph>="2.3.5"
 d3heatmap
 colourmap>="1.1.10"
 ismember>=1.0.1
-sklearn
+scikit-learn
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setuptools.setup(
-     install_requires=['numpy', 'pandas', 'tqdm', 'colourmap>=1.1.10', 'jinja2', 'd3graph>=2.3.5', 'd3heatmap', 'requests', 'ismember>=1.0.1', 'sklearn'],
+     install_requires=['numpy', 'pandas', 'tqdm', 'colourmap>=1.1.10', 'jinja2', 'd3graph>=2.3.5', 'd3heatmap', 'requests', 'ismember>=1.0.1', 'scikit-learn'],
      python_requires='>=3',
      name='d3blocks',
      version=new_version,


### PR DESCRIPTION
- replaced sklearn by scikit-learn in setup.py and requirements.txt
- removed explicit sklearn install from github workflow (as it is already in requirements.txt)``
